### PR TITLE
This is to redirect the <xsl:message> to the Log4j log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
+<!-- pour test -->
     <groupId>top.marchand.xml</groupId>
     <artifactId>gaulois-pipe</artifactId>
     <version>1.00.01-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-<!-- pour test -->
+
     <groupId>top.marchand.xml</groupId>
     <artifactId>gaulois-pipe</artifactId>
     <version>1.00.01-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,16 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+  <repositories>
+        <repository>
+            <id>els-nexus-public</id>
+            <url>http://srvic/nexus/content/groups/public</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.2</version>
                 <configuration>
-                    <finalName>${project.artifact}-${project.version}</finalName>
+                    <finalName>${project.build.finalName}</finalName>
                     <archive>
                         <manifest>
                             <addClasspath>true</addClasspath>

--- a/src/main/java/fr/efl/chaine/xslt/GauloisPipe.java
+++ b/src/main/java/fr/efl/chaine/xslt/GauloisPipe.java
@@ -22,6 +22,7 @@ import fr.efl.chaine.xslt.config.Xslt;
 import fr.efl.chaine.xslt.utils.ParametersMerger;
 import fr.efl.chaine.xslt.utils.ParametrableFile;
 import fr.efl.chaine.xslt.utils.SaxonConfigurationFactory;
+import fr.efl.chaine.xslt.utils.XsltMessageListener;
 import net.sf.saxon.s9api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -487,6 +488,9 @@ public class GauloisPipe {
 
                 xsl = xsltCompiler.compile(source);
                 xslCache.put(__href, xsl);
+				XsltTransformer transformer = xsl.load();
+        		transformer.setMessageListener(new XsltMessageListener(__href));
+				return transformer;
             } catch(SaxonApiException ex) {
                 LOGGER.error("while compiling "+__href);
                 LOGGER.error("SaxonAPIException: "+ex.getSystemId()+":"+ex.getLineNumber()+" "+ex.getErrorCode()+":"+ex.getMessage());

--- a/src/main/java/fr/efl/chaine/xslt/utils/XsltMessageListener.java
+++ b/src/main/java/fr/efl/chaine/xslt/utils/XsltMessageListener.java
@@ -1,0 +1,71 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package fr.efl.chaine.xslt.utils;
+
+import fr.efl.chaine.xslt.GauloisPipe;
+import javax.xml.transform.SourceLocator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.sf.saxon.s9api.Axis;
+import net.sf.saxon.s9api.MessageListener;
+import net.sf.saxon.s9api.QName;
+import net.sf.saxon.s9api.XdmNode;
+import net.sf.saxon.s9api.XdmNodeKind;
+
+public class XsltMessageListener implements MessageListener {
+
+    private String nomXSLT="";
+   private Logger logger ;
+
+    public XsltMessageListener(String nomXSLT) {
+        super();
+        this.nomXSLT = "." + nomXSLT.replaceAll("[:/.]", "_");
+          logger = LoggerFactory.getLogger(GauloisPipe.class.getName()+ this.nomXSLT );
+          
+    }
+   public XsltMessageListener() {
+        super();
+        this.nomXSLT = ".XSLT";
+           logger = LoggerFactory.getLogger(GauloisPipe.class.getName() + ".XSLT" );
+       
+    }
+    
+    @Override
+    public void message(XdmNode content, boolean terminate, SourceLocator locator) {
+        /*
+         * Le contenu du message (content) est soit directement du texte,
+         * soit un document XML de type log qui suit la structure suivante : 
+         * <log level="niveau de log" 
+         * 		source="xslt ou schéma sch source" ... >Message du log</log>
+         */
+
+        XdmNode xdmMessage = (XdmNode) content.axisIterator(Axis.CHILD).next();
+        String textMessage = xdmMessage.getStringValue();
+        XdmNodeKind kind = xdmMessage.getNodeKind();
+        if (kind.equals(XdmNodeKind.TEXT)) {
+             logger.info((terminate?"[TERMINATE] ":"")+textMessage);
+        } else {
+            String level = xdmMessage.getAttributeValue(new QName("level"));
+            String channel = xdmMessage.getAttributeValue(new QName("channel"));            
+            Logger loggerLocal = LoggerFactory.getLogger(GauloisPipe.class.getName() + (channel==null? "" : "." +channel) + nomXSLT);
+            switch (level) {
+                case "info":
+                    loggerLocal.info((terminate?"[TERMINATE] ":"")+textMessage);
+                    break;
+                case "warn":
+                    loggerLocal.warn((terminate?"[TERMINATE] ":"")+textMessage);
+                    break;
+                case "error":
+                    loggerLocal.error((terminate?"[TERMINATE] ":"")+textMessage);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/src/test/resources/uppercase.xsl
+++ b/src/test/resources/uppercase.xsl
@@ -26,6 +26,10 @@ can obtain one at https://mozilla.org/MPL/2.0/.
         </xd:desc>
     </xd:doc>
     <xsl:template match="*">
+        <xsl:message>Message sans log</xsl:message>
+        <xsl:message><log channel="MARC" level="info">Message avec log et channel</log></xsl:message>
+        <xsl:message><log level="error">Message niveau error sans channel</log></xsl:message>
+        
         <xsl:element name="{upper-case(local-name(.))}" namespace="{namespace-uri(.)}">
             <xsl:apply-templates select="node() | @*"/>
         </xsl:element>


### PR DESCRIPTION
This is a solution to wait a more global solution.
Here tje message are redirect to GauloisPipe channel and you can give more precision about it with an element <log> in the xsl:message, the default is "XSLT"
